### PR TITLE
et-metadata

### DIFF
--- a/et-tt/et-metadata.adoc
+++ b/et-tt/et-metadata.adoc
@@ -3,7 +3,13 @@
 === Terms of Reference
 
 [loweralpha]
-. Develop and maintain WMO standards for discovery metadata, notification metadata, topic hierarchy, and monitoring / alerting metadata in the Manual on WIS(WMO 1060), Vol. II, Guide to WIS (WMO-No. 1061), Vol. II, Manual on Codes (WMO-No.306), Vol I.3 and WIGOS Metadata Standard (WMO-No.1192) based on the W3C, OGC and ISO/TC 211 series of international standards to meet the needs of Members, WIS, WIGOS, WMO Earth system disciplines/domains and partner organizations;
+. Develop and maintain WMO standards for metadata (discovery, observations, provenance, WIS2 notifications, WIS2 topic hierarchy, and WIS2 monitoring / alerting) based on the W3C, OGC and ISO/TC 211 series of international standards to meet the needs of Members, WIS, WIGOS, WMO Earth system disciplines/domains and partner organizations;
+. Documentation of the WMO metadata standards in the:
+[lowerroman]
+.. Manual on WIS (WMO 1060), Vol. II;
+.. Guide to WIS (WMO-No. 1061), Vol. II;
+.. Manual on Codes (WMO-No. 306), Vol I.3;
+.. and WIGOS Metadata Standard (WMO-No. 1192);
 . Develop and maintain quality assessment frameworks in order to facilitate the continuous improvement of metadata management, discovery and use;
 . Collaborate with relevant standards bodies (such as OGC and ISO) to ensure that the metadata requirements and standards are harmonized to meet the needs and reduce the operational impact to WMO members;
 . Perform a comparative analysis of WMO Core Metadata Profile v2, WIS Notification Message, WIGOS Metadata Standard, vocabularies, and use of persistent identifiers in order to provide recommendations and options on future evolution and/or harmonization;

--- a/et-tt/et-metadata.adoc
+++ b/et-tt/et-metadata.adoc
@@ -9,7 +9,7 @@
 .. Manual on WIS (WMO 1060), Vol. II;
 .. Guide to WIS (WMO-No. 1061), Vol. II;
 .. Manual on Codes (WMO-No. 306), Vol I.3;
-.. and WIGOS Metadata Standard (WMO-No. 1192);
+.. WIGOS Metadata Standard (WMO-No. 1192);
 . Develop and maintain quality assessment frameworks in order to facilitate the continuous improvement of metadata management, discovery and use;
 . Collaborate with relevant standards bodies (such as OGC and ISO) to ensure that the metadata requirements and standards are harmonized to meet the needs and reduce the operational impact to WMO members;
 . Perform a comparative analysis of WMO Core Metadata Profile v2, WIS Notification Message, WIGOS Metadata Standard, vocabularies, and use of persistent identifiers in order to provide recommendations and options on future evolution and/or harmonization;


### PR DESCRIPTION
- inclusion of observations and provenance metadata (to cover climate & tt-cdm) in first item
- split of first item into two items, one on developing the standards, the other documenting.